### PR TITLE
Fix test_serializer_class_map_view_schema

### DIFF
--- a/restdoctor/rest_framework/schema/openapi.py
+++ b/restdoctor/rest_framework/schema/openapi.py
@@ -65,9 +65,9 @@ class RestDoctorSchema(AutoSchema):
         if is_list_view(path, method, self.view):
             return 'list'
         elif action not in self.method_mapping:
-            return action
+            return action.lower()
         else:
-            return self.method_mapping[method.lower()]
+            return self.method_mapping[method.lower()].lower()
 
     def get_object_name_by_view_class_name(self, clean_suffixes: typing.Sequence[str] = None) -> str:
         clean_suffixes = clean_suffixes or []

--- a/tests/test_unit/test_schema/test_serializer_class_map.py
+++ b/tests/test_unit/test_schema/test_serializer_class_map.py
@@ -54,7 +54,5 @@ def test_serializer_class_map_view_schema(
     if 'items' in responses_properties:
         responses_properties = responses_properties['items']
 
-    print(responses_schema)
-
     assert result['operationId'] == expected_operation_id
     assert responses_properties['required'] == expected_responses_required


### PR DESCRIPTION
Specified test doen't pass because of upper capitalized values of rest_framework.schemas.openapi.AutoSchema.method_mapping
In django rest framework version 3.11.0 it is so. However in further versions values are lowercased.  