### PR TITLE
Add verbose filter description for DjangoFilterBackend and restrict no label

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,2 +1,3 @@
 djangorestframework==3.12.2
 uritemplate==3.0.1
+django-filter==2.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,10 +8,16 @@ asgiref==3.2.10 \
     --hash=sha256:7e51911ee147dd685c3c8b805c0ad0cb58d360987b56953878f8c06d2d1c6f1a \
     --hash=sha256:9fc6fb5d39b8af147ba40765234fa822b39818b12cc80b35ad9b0cef3a476aed \
     # via django
+django-filter==2.4.0 \
+    --hash=sha256:84e9d5bb93f237e451db814ed422a3a625751cbc9968b484ecc74964a8696b06 \
+    --hash=sha256:e00d32cebdb3d54273c48f4f878f898dced8d5dfaad009438fe61ebdf535ace1
+    # via -r requirements.in
 django==3.1.1 \
     --hash=sha256:59c8125ca873ed3bdae9c12b146fbbd6ed8d0f743e4cf5f5817af50c51f1fc2f \
     --hash=sha256:b5fbb818e751f660fa2d576d9f40c34a4c615c8b48dd383f5216e609f383371f \
-    # via djangorestframework
+    # via
+    #   django-filter
+    #   djangorestframework
 djangorestframework==3.12.2 \
     --hash=sha256:0209bafcb7b5010fdfec784034f059d512256424de2a0f084cb82b096d6dd6a7 \
     --hash=sha256:0898182b4737a7b584a2c73735d89816343369f259fea932d90dc78e35d8ac33 \

--- a/tests/stubs/models.py
+++ b/tests/stubs/models.py
@@ -9,5 +9,33 @@ class MyModel(models.Model):
         app_label = 'restdoctor'
 
     uuid = models.UUIDField(  # null_for_compatibility
-        default=uuid.uuid4, editable=False, null=True, unique=True)
+        default=uuid.uuid4, editable=False, null=True, unique=True
+    )
     timestamp = models.DateTimeField('Event timestamp', default=timezone.localtime)
+
+
+class MyAnotherModel(models.Model):
+    class Meta:
+        app_label = 'restdoctor'
+
+    uuid = models.UUIDField(  # null_for_compatibility
+        verbose_name='UUID', default=uuid.uuid4, editable=False, null=True, unique=True
+    )
+    timestamp = models.DateTimeField('Another Event timestamp', default=timezone.localtime)
+    my_model = models.ForeignKey(MyModel, verbose_name='My Model', on_delete=models.CASCADE)
+
+
+class MyAnotherOneModel(models.Model):
+    class Meta:
+        app_label = 'restdoctor'
+
+    my_another_model = models.OneToOneField(
+        MyAnotherModel,
+        verbose_name='My Another Model',
+        related_name='my_another_one_model',
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+    )
+
+    timestamp = models.DateTimeField('Another One Event timestamp', default=timezone.localtime)

--- a/tests/test_unit/test_schema/conftest.py
+++ b/tests/test_unit/test_schema/conftest.py
@@ -28,6 +28,7 @@ def get_create_view_func():
             return view
 
         return create_view
+
     return with_args
 
 
@@ -35,6 +36,7 @@ def get_create_view_func():
 def get_resource_ref():
     def with_attrs(name, suffix):
         return {'$ref': f'#/components/schemas/{name}{suffix}'}
+
     return with_attrs
 
 
@@ -42,6 +44,7 @@ def get_resource_ref():
 def resource_default_ref(get_resource_ref):
     def with_attrs(suffix):
         return get_resource_ref('tests_Default', suffix)
+
     return with_attrs
 
 
@@ -49,6 +52,7 @@ def resource_default_ref(get_resource_ref):
 def resource_another_ref(get_resource_ref):
     def with_attrs(suffix):
         return get_resource_ref('tests_Another', suffix)
+
     return with_attrs
 
 
@@ -56,6 +60,7 @@ def resource_another_ref(get_resource_ref):
 def get_object_schema():
     def with_attrs(schema):
         return {'type': 'object', 'properties': {'data': schema}}
+
     return with_attrs
 
 

--- a/tests/test_unit/test_schema/conftest.py
+++ b/tests/test_unit/test_schema/conftest.py
@@ -4,7 +4,7 @@ from rest_framework.routers import SimpleRouter
 
 from restdoctor.rest_framework.schema import RefsSchemaGenerator
 from restdoctor.rest_framework.viewsets import ModelViewSet
-from tests.stubs.models import MyModel
+from tests.stubs.models import MyAnotherModel
 from tests.stubs.serializers import MyModelSerializer
 
 
@@ -89,7 +89,7 @@ def viewset_with_filter_backends_factory():
     def viewset_with_filter_backend(backends, filterset, **kwargs):
         class ModelViewSetWithFilterBackend(ModelViewSet):
             pagination_class = None
-            queryset = MyModel.objects.all()
+            queryset = MyAnotherModel.objects.all()
             serializer_class = MyModelSerializer
             filter_backends = backends
             filterset_class = filterset

--- a/tests/test_unit/test_schema/conftest.py
+++ b/tests/test_unit/test_schema/conftest.py
@@ -3,6 +3,9 @@ from django.urls import resolve
 from rest_framework.routers import SimpleRouter
 
 from restdoctor.rest_framework.schema import RefsSchemaGenerator
+from restdoctor.rest_framework.viewsets import ModelViewSet
+from tests.stubs.models import MyModel
+from tests.stubs.serializers import MyModelSerializer
 
 
 class UrlConf:
@@ -74,3 +77,18 @@ def resource_another_rq_schema(get_object_schema, resource_another_ref):
 @pytest.fixture()
 def resource_another_wq_schema(get_object_schema, resource_another_ref):
     return get_object_schema(resource_another_ref('WQ'))
+
+
+@pytest.fixture()
+def viewset_with_filter_backends_factory():
+    def viewset_with_filter_backend(backends, filterset, **kwargs):
+        class ModelViewSetWithFilterBackend(ModelViewSet):
+            pagination_class = None
+            queryset = MyModel.objects.all()
+            serializer_class = MyModelSerializer
+            filter_backends = backends
+            filterset_class = filterset
+
+        return ModelViewSetWithFilterBackend
+
+    return viewset_with_filter_backend

--- a/tests/test_unit/test_schema/stubs.py
+++ b/tests/test_unit/test_schema/stubs.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from django.db.models import QuerySet
+from django_filters import DateFilter
+from django_filters.rest_framework import FilterSet
 from rest_framework.decorators import action as drf_action
 from rest_framework.fields import CharField, UUIDField
 from rest_framework.serializers import Serializer
@@ -7,6 +10,7 @@ from rest_framework.serializers import Serializer
 from restdoctor.rest_framework.resources import ResourceViewSet
 from restdoctor.rest_framework.views import SerializerClassMapApiView
 from restdoctor.rest_framework.viewsets import ListModelViewSet, ModelViewSet
+from tests.stubs.models import MyModel
 
 
 class DefaultSerializer(Serializer):
@@ -98,3 +102,37 @@ class DefaultAnotherResourceViewSet(ResourceViewSet):
 class SingleResourceViewSet(ResourceViewSet):
     default_discriminative_value = 'default'
     resource_views_map = {'another': AnotherViewSet}
+
+
+class DefaultFilterSet(FilterSet):
+    class Meta:
+        model = MyModel
+        fields = ['uuid', 'timestamp']
+
+
+class FilterSetWithNoLabels(FilterSet):
+    class Meta:
+        model = MyModel
+        fields = ['uuid', 'created_at_date']
+
+    created_at_date = DateFilter(field_name='timestamp', lookup_expr='date__exact')
+    created_after = DateFilter(method='filter_created_after')
+
+    @staticmethod
+    def filter_created_after(queryset: QuerySet, name: str, value: str) -> QuerySet:
+        return queryset.filter(timestamp__gte=value)
+
+
+class FilterSetWithLabels(FilterSet):
+    class Meta:
+        model = MyModel
+        fields = ['uuid', 'created_at_date']
+
+    created_at_date = DateFilter(
+        label='Timestamp Label', field_name='timestamp', lookup_expr='date__exact'
+    )
+    created_after = DateFilter(label='Created After Label', method='filter_created_after')
+
+    @staticmethod
+    def filter_created_after(queryset: QuerySet, name: str, value: str) -> QuerySet:
+        return queryset.filter(timestamp__gte=value)

--- a/tests/test_unit/test_schema/stubs.py
+++ b/tests/test_unit/test_schema/stubs.py
@@ -10,7 +10,7 @@ from rest_framework.serializers import Serializer
 from restdoctor.rest_framework.resources import ResourceViewSet
 from restdoctor.rest_framework.views import SerializerClassMapApiView
 from restdoctor.rest_framework.viewsets import ListModelViewSet, ModelViewSet
-from tests.stubs.models import MyModel
+from tests.stubs.models import MyAnotherModel
 
 
 class DefaultSerializer(Serializer):
@@ -106,14 +106,19 @@ class SingleResourceViewSet(ResourceViewSet):
 
 class DefaultFilterSet(FilterSet):
     class Meta:
-        model = MyModel
+        model = MyAnotherModel
         fields = ['uuid', 'timestamp']
 
 
 class FilterSetWithNoLabels(FilterSet):
     class Meta:
-        model = MyModel
-        fields = ['uuid', 'created_at_date']
+        model = MyAnotherModel
+        fields = {
+            'uuid': ['exact'],
+            'my_model__timestamp': ['exact', 'in'],
+            'my_another_one_model': ['isnull'],
+            'my_another_one_model__timestamp': ['exact'],
+        }
 
     created_at_date = DateFilter(field_name='timestamp', lookup_expr='date__exact')
     created_after = DateFilter(method='filter_created_after')
@@ -125,13 +130,13 @@ class FilterSetWithNoLabels(FilterSet):
 
 class FilterSetWithLabels(FilterSet):
     class Meta:
-        model = MyModel
-        fields = ['uuid', 'created_at_date']
+        model = MyAnotherModel
+        fields = ['uuid', 'my_model__timestamp', 'my_another_one_model__timestamp']
 
     created_at_date = DateFilter(
-        label='Timestamp Label', field_name='timestamp', lookup_expr='date__exact'
+        label='Created At Timestamp Label', field_name='timestamp', lookup_expr='date__exact'
     )
-    created_after = DateFilter(label='Created After Label', method='filter_created_after')
+    created_after = DateFilter(label='Custom Method Label', method='filter_created_after')
 
     @staticmethod
     def filter_created_after(queryset: QuerySet, name: str, value: str) -> QuerySet:

--- a/tests/test_unit/test_schema/test_query_schema.py
+++ b/tests/test_unit/test_schema/test_query_schema.py
@@ -16,7 +16,8 @@ from tests.test_unit.test_schema.stubs import (
     'viewset,expected_parameters',
     (
         (
-            ListViewSetWithRequestSerializer, [
+            ListViewSetWithRequestSerializer,
+            [
                 {
                     'in': 'query',
                     'name': 'filter_uuid_field',
@@ -54,7 +55,8 @@ def test_schema_for_list_viewset(get_create_view_func, viewset, expected_paramet
     'viewset,expected_parameters',
     (
         (
-            ListViewSetWithRequestSerializer, [
+            ListViewSetWithRequestSerializer,
+            [
                 {
                     'in': 'query',
                     'name': 'filter_uuid_field',
@@ -79,7 +81,9 @@ def test_schema_for_list_viewset(get_create_view_func, viewset, expected_paramet
         (ListViewSetWithoutRequestSerializer, []),
     ),
 )
-def test_get_request_serializer_filter_parameters(get_create_view_func, viewset, expected_parameters):
+def test_get_request_serializer_filter_parameters(
+    get_create_view_func, viewset, expected_parameters
+):
     list_view = get_create_view_func('test', viewset, 'test')
 
     view = list_view('/test/', 'GET')

--- a/tests/test_unit/test_schema/test_query_schema.py
+++ b/tests/test_unit/test_schema/test_query_schema.py
@@ -100,14 +100,14 @@ def test_get_request_serializer_filter_parameters(
             DefaultFilterSet,
             [
                 {
-                    'description': 'uuid',
+                    'description': 'UUID',
                     'in': 'query',
                     'name': 'uuid',
                     'required': False,
                     'schema': {'type': 'string'},
                 },
                 {
-                    'description': 'Event timestamp',
+                    'description': 'Another Event timestamp',
                     'in': 'query',
                     'name': 'timestamp',
                     'required': False,
@@ -127,7 +127,7 @@ def test_get_request_serializer_filter_parameters(
             FilterSetWithNoLabels,
             [
                 {
-                    'description': 'uuid',
+                    'description': 'UUID',
                     'in': 'query',
                     'name': 'uuid',
                     'required': False,
@@ -135,6 +135,34 @@ def test_get_request_serializer_filter_parameters(
                 },
                 {
                     'description': 'Event timestamp',
+                    'in': 'query',
+                    'name': 'my_model__timestamp',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'Event timestamp',
+                    'in': 'query',
+                    'name': 'my_model__timestamp__in',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'my another one model',
+                    'in': 'query',
+                    'name': 'my_another_one_model__isnull',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'Another One Event timestamp',
+                    'in': 'query',
+                    'name': 'my_another_one_model__timestamp',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'Another Event timestamp',
                     'in': 'query',
                     'name': 'created_at_date',
                     'required': False,
@@ -154,21 +182,35 @@ def test_get_request_serializer_filter_parameters(
             FilterSetWithLabels,
             [
                 {
-                    'description': 'uuid',
+                    'description': 'UUID',
                     'in': 'query',
                     'name': 'uuid',
                     'required': False,
                     'schema': {'type': 'string'},
                 },
                 {
-                    'description': 'Timestamp Label',
+                    'description': 'Event timestamp',
+                    'in': 'query',
+                    'name': 'my_model__timestamp',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'Another One Event timestamp',
+                    'in': 'query',
+                    'name': 'my_another_one_model__timestamp',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'Created At Timestamp Label',
                     'in': 'query',
                     'name': 'created_at_date',
                     'required': False,
                     'schema': {'type': 'string'},
                 },
                 {
-                    'description': 'Created After Label',
+                    'description': 'Custom Method Label',
                     'in': 'query',
                     'name': 'created_after',
                     'required': False,
@@ -192,6 +234,19 @@ def test_schema_for_viewset_with_filter_backend(
     operation = view.schema.get_operation('/test/', 'GET')
 
     assert operation['parameters'] == expected_parameters
+
+
+def test_schema_for_viewset_with_filter_backend_strict_schema(
+    settings,
+    get_create_view_func,
+    viewset_with_filter_backends_factory,
+):
+    settings.API_STRICT_SCHEMA_VALIDATION = True
+    viewset = viewset_with_filter_backends_factory([DjangoFilterBackend], FilterSetWithLabels)
+    create_view = get_create_view_func('test', viewset, 'test')
+    view = create_view('/test/', 'GET')
+
+    view.schema.get_operation('/test/', 'GET')
 
 
 def test_schema_for_viewset_with_filter_backend_strict_schema_raises(

--- a/tests/test_unit/test_schema/test_query_schema.py
+++ b/tests/test_unit/test_schema/test_query_schema.py
@@ -1,6 +1,15 @@
 import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework.filters import OrderingFilter
 
-from tests.test_unit.test_schema.stubs import ListViewSetWithRequestSerializer, ListViewSetWithoutRequestSerializer
+from tests.test_unit.test_schema.stubs import (
+    ListViewSetWithRequestSerializer,
+    ListViewSetWithoutRequestSerializer,
+    DefaultFilterSet,
+    FilterSetWithNoLabels,
+    FilterSetWithLabels,
+)
 
 
 @pytest.mark.parametrize(
@@ -77,3 +86,119 @@ def test_get_request_serializer_filter_parameters(get_create_view_func, viewset,
     parameters = view.schema.get_request_serializer_filter_parameters('/test/', 'GET')
 
     assert parameters == expected_parameters
+
+
+@pytest.mark.parametrize(
+    'filter_backends,filterset_class,expected_parameters',
+    (
+        (
+            [DjangoFilterBackend, OrderingFilter],
+            DefaultFilterSet,
+            [
+                {
+                    'description': 'uuid',
+                    'in': 'query',
+                    'name': 'uuid',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'Event timestamp',
+                    'in': 'query',
+                    'name': 'timestamp',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'Which field to use when ordering the results.',
+                    'in': 'query',
+                    'name': 'ordering',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+            ],
+        ),
+        (
+            [DjangoFilterBackend],
+            FilterSetWithNoLabels,
+            [
+                {
+                    'description': 'uuid',
+                    'in': 'query',
+                    'name': 'uuid',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'Event timestamp',
+                    'in': 'query',
+                    'name': 'created_at_date',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'created_after',
+                    'in': 'query',
+                    'name': 'created_after',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+            ],
+        ),
+        (
+            [DjangoFilterBackend],
+            FilterSetWithLabels,
+            [
+                {
+                    'description': 'uuid',
+                    'in': 'query',
+                    'name': 'uuid',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'Timestamp Label',
+                    'in': 'query',
+                    'name': 'created_at_date',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+                {
+                    'description': 'Created After Label',
+                    'in': 'query',
+                    'name': 'created_after',
+                    'required': False,
+                    'schema': {'type': 'string'},
+                },
+            ],
+        ),
+    ),
+)
+def test_schema_for_viewset_with_filter_backend(
+    get_create_view_func,
+    viewset_with_filter_backends_factory,
+    filter_backends,
+    filterset_class,
+    expected_parameters,
+):
+    viewset = viewset_with_filter_backends_factory(filter_backends, filterset_class)
+    create_view = get_create_view_func('test', viewset, 'test')
+
+    view = create_view('/test/', 'GET')
+    operation = view.schema.get_operation('/test/', 'GET')
+
+    assert operation['parameters'] == expected_parameters
+
+
+def test_schema_for_viewset_with_filter_backend_strict_schema_raises(
+    settings,
+    get_create_view_func,
+    viewset_with_filter_backends_factory,
+):
+    settings.API_STRICT_SCHEMA_VALIDATION = True
+    viewset = viewset_with_filter_backends_factory([DjangoFilterBackend], FilterSetWithNoLabels)
+    create_view = get_create_view_func('test', viewset, 'test')
+    view = create_view('/test/', 'GET')
+
+    with pytest.raises(ImproperlyConfigured):
+        view.schema.get_operation('/test/', 'GET')

--- a/tests/test_unit/test_schema/test_resource_schema.py
+++ b/tests/test_unit/test_schema/test_resource_schema.py
@@ -124,7 +124,7 @@ def test_get_action_responses_success_case(get_create_view_func, resource_defaul
     ('viewset_class'),
     [(DefaultAnotherResourceViewSet), (SingleResourceViewSet)],
     ids=[
-        'get params from defauilt viewset in resource',
+        'get params from default viewset in resource',
         'get params from single viewset in resource',
     ],
 )


### PR DESCRIPTION
- Get schema filter description from `verbose_name` if possible
- Filter's `label` or Filter's target ModelField `verbose_name` are now required if `API_STRICT_SCHEMA_VALIDATION = True`, raises `ImproperlyConfigured` if not provided
- Removed `not compatible with schema generation` warning