### PR TITLE
Treat serializer data always as dict. Don't deepcopy TemporaryUploadedFile

### DIFF
--- a/restdoctor/rest_framework/sensitive_data.py
+++ b/restdoctor/rest_framework/sensitive_data.py
@@ -5,6 +5,7 @@ import copy
 import inspect
 import typing
 
+from django.core.files.uploadedfile import TemporaryUploadedFile
 from django.db.models import Model
 from rest_framework.fields import SerializerMethodField
 from rest_framework.serializers import Serializer, ListSerializer
@@ -15,7 +16,7 @@ if typing.TYPE_CHECKING:
     SerializerClassOrInstance = typing.Union[typing.Type[Serializer], Serializer]
     SensitiveDataConfig = typing.Dict[str, typing.Any]
     SensitiveDataConfigValue = typing.Union[bool, SensitiveDataConfig]
-    SerializerData = typing.Union[typing.Dict[str, typing.Any], typing.List[typing.Dict[str, typing.Any]]]
+    SerializerData = typing.Dict[str, typing.Any]
 
 
 def get_serializer_sensitive_fields(
@@ -96,11 +97,22 @@ def get_field_sensitive_data_config(
     return result
 
 
+def smart_copy(data: SerializerData, no_copy_classes: typing.List) -> SerializerData:
+    new_data = {}
+    for field_name, field_value in data.items():
+        if any([isinstance(field_value, no_copy_class) for no_copy_class in no_copy_classes]):
+            new_data[field_name] = field_value
+        else:
+            new_data[field_name] = copy.deepcopy(field_value)
+
+    return new_data
+
+
 def clear_sensitive_data(
     data: SerializerData,
     serializer: SerializerClassOrInstance,
 ) -> SerializerData:
-    data = copy.deepcopy(data)
+    data = smart_copy(data, [TemporaryUploadedFile])
 
     try:
         sensitive_data_config = get_serializer_sensitive_data_config(serializer)
@@ -119,10 +131,7 @@ def clear_sensitive_data(
 def clear_sensitive_field(
     field_name: str, field_value: typing.Any, data: SerializerData,
 ) -> None:
-    if isinstance(data, list):
-        for data_item in data:
-            clear_sensitive_field(field_name, field_value, data_item)
-    elif isinstance(data, dict) and field_name in data:
+    if isinstance(data, dict) and field_name in data:
         if isinstance(field_value, dict):
             for related_field_name, related_field_value in field_value.items():
                 clear_sensitive_field(related_field_name, related_field_value, data[field_name])

--- a/restdoctor/rest_framework/views.py
+++ b/restdoctor/rest_framework/views.py
@@ -11,7 +11,6 @@ from restdoctor.rest_framework.mixins import ListModelMixin, RetrieveModelMixin
 from restdoctor.rest_framework.sensitive_data import clear_sensitive_data
 from restdoctor.rest_framework.signals import bind_extra_request_view_initial_metadata
 from restdoctor.utils.permissions import get_permission_classes_from_map
-from restdoctor.utils.sentry import capture_exception
 from restdoctor.utils.serializers import get_serializer_class_from_map
 from restdoctor.utils.structlog import get_logger
 
@@ -64,7 +63,6 @@ class SerializerClassMapApiView(GenericAPIView):
             try:
                 request_data = self.clear_request_data(request)
             except Exception:
-                capture_exception()
                 request_data = None
 
             logger.info(


### PR DESCRIPTION
As  deepcopy doesn't work on TemporaryUploadedFile.
Also removed capture_exception