### PR TITLE
BBANG-24: Error out on non-unique schema operation id

### DIFF
--- a/restdoctor/rest_framework/schema/openapi.py
+++ b/restdoctor/rest_framework/schema/openapi.py
@@ -139,6 +139,11 @@ class RestDoctorSchema(ViewSchemaProtocol, AutoSchema):
 
     def get_operation_id(self, path: str, method: str) -> str:
         action_name = self.get_action_name(path, method)
+
+        schema_operation_id_map = getattr(self.view, 'schema_operation_id_map', None)
+        if schema_operation_id_map and action_name in schema_operation_id_map:
+            return schema_operation_id_map[action_name]
+
         object_name = self.get_object_name(path, method, action_name)
 
         if action_name == 'list' and not object_name.endswith(

--- a/tests/test_unit/test_schema/conftest.py
+++ b/tests/test_unit/test_schema/conftest.py
@@ -11,7 +11,8 @@ from tests.stubs.serializers import MyModelSerializer
 
 
 class UrlConf:
-    urlpatterns = []
+    def __init__(self, urlpatterns=None) -> None:
+        self.urlpatterns = urlpatterns or []
 
 
 @pytest.fixture()
@@ -30,6 +31,18 @@ def get_create_view_func():
             return view
 
         return create_view
+
+    return with_args
+
+
+@pytest.fixture()
+def make_urlconf():
+    def with_args(*routes):
+        router = SimpleRouter()
+        for prefix, viewset, basename in routes:
+            router.register(prefix, viewset, basename)
+
+        return UrlConf(urlpatterns=router.urls)
 
     return with_args
 

--- a/tests/test_unit/test_schema/stubs.py
+++ b/tests/test_unit/test_schema/stubs.py
@@ -64,6 +64,17 @@ class AnotherViewSet(ModelViewSet):
     serializer_class = AnotherSerializer
 
 
+class DefaultViewSetWithOperationId(DefaultViewSet):
+    schema_operation_id_map = {
+        'list': 'listDefautBars',
+        'retrieve': 'getDefautBar',
+        'create': 'createDefautBar',
+        'update': 'updateDefautBar',
+        'partial_update': 'partialUpdateDefautBar',
+        'destroy': 'deleteDefautBar',
+    }
+
+
 class ActionsViewSet(ModelViewSet):
     serializer_class = DefaultSerializer
 

--- a/tests/test_unit/test_schema/test_operation_ids.py
+++ b/tests/test_unit/test_schema/test_operation_ids.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from tests.test_unit.test_schema.stubs import DefaultViewSet
+
+
+def test_override_operation_id(get_create_view_func):
+    create_view = get_create_view_func('test', DefaultViewSet, 'test')
+
+    view = create_view('/test/', 'GET')
+    view.schema_operation_id_map = {'list': 'custom_id'}
+    operation = view.schema.get_operation('/test/', 'GET')
+
+    assert operation['operationId'] == 'custom_id'

--- a/tests/test_unit/test_schema/test_schema_validations.py
+++ b/tests/test_unit/test_schema/test_schema_validations.py
@@ -3,9 +3,13 @@ from __future__ import annotations
 import pytest
 from django.core.exceptions import ImproperlyConfigured
 from rest_framework.fields import Field
+from rest_framework.routers import SimpleRouter
 
 from restdoctor.rest_framework.schema import RestDoctorSchema
+from restdoctor.rest_framework.schema.generators import RefsSchemaGenerator30
 from tests.stubs.serializers import MyModelWithoutHelpTextsSerializer, WithMethodFieldSerializer
+from tests.test_unit.test_schema.conftest import UrlConf
+from tests.test_unit.test_schema.stubs import DefaultViewSet, DefaultViewSetWithOperationId
 
 
 @pytest.mark.parametrize(
@@ -102,3 +106,21 @@ def test_check_annotations_fail_case(settings, field):
 
     with pytest.raises(ImproperlyConfigured):
         schema.map_field(serializer.fields[field])
+
+
+def test_duplicate_operation_ids_fail_case(make_urlconf):
+    urlconf = make_urlconf(('foo', DefaultViewSet, 'foo'), ('bar', DefaultViewSet, 'bar'))
+    generator = RefsSchemaGenerator30(urlconf=urlconf)
+
+    with pytest.raises(Exception, match='duplicates existing id'):
+        generator.get_schema()
+
+
+def test_duplicate_operation_ids_success_case(make_urlconf):
+    urlconf = make_urlconf(
+        ('foo', DefaultViewSet, 'foo'), ('bar', DefaultViewSetWithOperationId, 'bar')
+    )
+    generator = RefsSchemaGenerator30(urlconf=urlconf)
+
+    schema = generator.get_schema()
+    pass


### PR DESCRIPTION
Raise a meaningful exception and add an option to set custom id per view to avoid conflicts