### PR TITLE
Add missing requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,5 +43,5 @@ setup(
     license='MIT',
     py_modules=['restdoctor'],
     zip_safe=False,
-    install_requires=['uritemplate==4.1.1', 'semver==2.13.0'],
+    install_requires=['uritemplate==4.1.1', 'semver==2.13.0', 'pyyaml==6.0'],
 )


### PR DESCRIPTION
Версия 0.0.44, при использовании генератора `restdoctor.rest_framework.schema.RefsSchemaGenerator` происходит такая ошибка:

```
Traceback (most recent call last):
  File "/myapp/manage.py", line 26, in <module>
    main()
  File "/myapp/manage.py", line 22, in main
    execute_from_command_line(sys.argv)
  File "/opt/venv/lib/python3.9/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/opt/venv/lib/python3.9/site-packages/django/core/management/__init__.py", line 413, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/venv/lib/python3.9/site-packages/django/core/management/base.py", line 354, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/venv/lib/python3.9/site-packages/django/core/management/base.py", line 398, in execute
    output = self.handle(*args, **options)
  File "/opt/venv/lib/python3.9/site-packages/rest_framework/management/commands/generateschema.py", line 42, in handle
    renderer = self.get_renderer(options['format'])
  File "/opt/venv/lib/python3.9/site-packages/rest_framework/management/commands/generateschema.py", line 64, in get_renderer
    return renderer_cls()
  File "/opt/venv/lib/python3.9/site-packages/rest_framework/renderers.py", line 1053, in __init__
    assert yaml, 'Using OpenAPIRenderer, but `pyyaml` is not installed.'
AssertionError: Using OpenAPIRenderer, but `pyyaml` is not installed.
```