### PR TITLE
Sensitive data in `PydanticSerializer`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_stages:
 
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v3.2.0
+  rev: v4.1.0
   hooks:
     - id: trailing-whitespace
     - id: double-quote-string-fixer
@@ -15,7 +15,7 @@ repos:
   hooks:
     - id: python-check-blanket-noqa
 
-- repo: https://gitlab.com/pycqa/flake8
+- repo: https://github.com/pycqa/flake8
   rev: '5.0.4'
   hooks:
     - id: flake8
@@ -64,6 +64,6 @@ repos:
       language_version: python
 
 - repo: https://github.com/PyCQA/isort
-  rev: '5.10.1'
+  rev: '5.12.0'
   hooks:
     - id: isort

--- a/restdoctor/rest_framework/serializers.py
+++ b/restdoctor/rest_framework/serializers.py
@@ -20,6 +20,8 @@ from rest_framework.utils import model_meta
 
 from restdoctor.utils.pydantic import convert_pydantic_errors_to_drf_errors
 
+TPydanticModel = typing.TypeVar('TPydanticModel', bound=BaseModel)
+
 
 def _is_serializer_subclass(obj: typing.Any) -> bool:
     try:
@@ -109,7 +111,7 @@ class ModelSerializer(BaseModelSerializer, Serializer, metaclass=ModelSerializer
     pass
 
 
-class PydanticSerializer(BaseDRFSerializer):
+class PydanticSerializer(typing.Generic[TPydanticModel], BaseDRFSerializer):
     """Serializer for pydantic models."""
 
     class Meta:
@@ -118,7 +120,7 @@ class PydanticSerializer(BaseDRFSerializer):
         pydantic_use_aliases: bool = False
 
     pydantic_model: typing.Optional[
-        typing.Type[BaseModel]
+        typing.Type[TPydanticModel]
     ] = None  # deprecated: use Meta.pydantic_model
 
     def __new__(cls, *args: list[typing.Any], **kwargs: dict[str, typing.Any]):  # type: ignore
@@ -136,21 +138,28 @@ class PydanticSerializer(BaseDRFSerializer):
         data: dict[str, typing.Any] | empty = empty,
         **kwargs: dict[str, typing.Any],
     ):
-        self._pydantic_instance: BaseModel | None = None
+        self._pydantic_instance: TPydanticModel | None = None
         self._setup_create_update_methods()
         super().__init__(instance=instance, data=data, **kwargs)
 
     @property
-    def pydantic_model_class(self) -> typing.Type[BaseModel]:
+    def pydantic_model_class(self) -> typing.Type[TPydanticModel]:
         # self.pydantic_model for backward, will be removed in future
         return getattr(self.Meta, 'pydantic_model', None) or self.pydantic_model  # type: ignore
+
+    @property
+    def pydantic_instance(self) -> TPydanticModel | None:
+        if not hasattr(self, '_validated_data'):
+            msg = 'You must call `.is_valid()` before accessing `.pydantic_instance`.'
+            raise AssertionError(msg)
+        return self._pydantic_instance
 
     @property
     def pydantic_use_aliases(self) -> bool:
         return getattr(self.Meta, 'pydantic_use_aliases', False)
 
     @classmethod
-    def _get_pydantic_model(cls) -> typing.Type[BaseModel]:
+    def _get_pydantic_model(cls) -> typing.Type[TPydanticModel]:
         # cls.pydantic_model for backward, will be removed in future
         pydantic_model = getattr(cls.Meta, 'pydantic_model', None) or cls.pydantic_model
         if pydantic_model is None:
@@ -192,7 +201,7 @@ class PydanticSerializer(BaseDRFSerializer):
                 'pydantic_model.Config.orm_mode must be True for this serializer'
             )
 
-    def to_internal_value(self, data: dict[str, typing.Any]) -> BaseModel:
+    def to_internal_value(self, data: dict[str, typing.Any]) -> TPydanticModel:
         try:
             pydantic_model = self.pydantic_model_class(**data)
         except PydanticValidationError as exc:
@@ -201,7 +210,7 @@ class PydanticSerializer(BaseDRFSerializer):
         return pydantic_model
 
     def to_representation(  # noqa: CAC001
-        self, instance: PydanticSerializer | BaseModel | DjangoModel | dict
+        self, instance: PydanticSerializer | TPydanticModel | DjangoModel | dict
     ) -> GenericRepresentation:
         # Типы аргумента instance были выяснены экспериментальным путем
         # в ходе тестирования

--- a/restdoctor/rest_framework/serializers.py
+++ b/restdoctor/rest_framework/serializers.py
@@ -201,6 +201,9 @@ class PydanticSerializer(typing.Generic[TPydanticModel], BaseDRFSerializer):
                 'pydantic_model.Config.orm_mode must be True for this serializer'
             )
 
+    def get_fields(self) -> dict[str, None]:
+        return {field_name: None for field_name in self.pydantic_model_class.__fields__.keys()}
+
     def to_internal_value(self, data: dict[str, typing.Any]) -> TPydanticModel:
         try:
             pydantic_model = self.pydantic_model_class(**data)

--- a/tests/test_unit/test_serializers/test_pydantic_serializer/conftest.py
+++ b/tests/test_unit/test_serializers/test_pydantic_serializer/conftest.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import datetime
+import typing
 
 import pytest
 from django.db import models
@@ -62,6 +63,20 @@ class TestPydanticSerializerWithAliasesDeprecated(PydanticSerializer):
         pydantic_use_aliases = True
 
     pydantic_model = PydanticTestModelWithAliases
+
+
+class TestPydanticDtoWithSensitiveData(BaseModel):
+    first_name: str
+    last_name: str
+    title: str
+
+
+class PydanticSerializerWithSensitiveData(PydanticSerializer):
+    class Meta:
+        pydantic_model = TestPydanticDtoWithSensitiveData
+
+    class SensitiveData:
+        include = ['first_name', 'last_name']
 
 
 @pytest.fixture()
@@ -154,3 +169,10 @@ def serialized_pydantic_test_model_with_aliases_data(
     return pydantic_test_model_with_aliases(**pydantic_test_model_with_aliases_data).dict(
         by_alias=True
     )
+
+
+@pytest.fixture()
+def pydantic_model_serializer_with_sensitive_data() -> typing.Type[
+    PydanticSerializerWithSensitiveData
+]:
+    return PydanticSerializerWithSensitiveData

--- a/tests/test_unit/test_serializers/test_pydantic_serializer/test_sensitive_data.py
+++ b/tests/test_unit/test_serializers/test_pydantic_serializer/test_sensitive_data.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import pytest
+
+from restdoctor.rest_framework.sensitive_data import (
+    clear_sensitive_data,
+    get_serializer_sensitive_data_config,
+)
+
+
+def test_get_serializer_sensitive_data_config_pydantic_serializer(
+    pydantic_model_serializer_with_sensitive_data,
+):
+    result = get_serializer_sensitive_data_config(pydantic_model_serializer_with_sensitive_data)
+
+    assert result == {'first_name': True, 'last_name': True}
+
+
+@pytest.mark.parametrize(
+    ('data', 'expected_data'),
+    [
+        ({'first_name': 'Иван', 'id': 1}, {'first_name': '[Cleaned]', 'id': 1}),
+        ({'last_name': 'Иванович', 'id': 1}, {'last_name': '[Cleaned]', 'id': 1}),
+        (
+            [{'first_name': 'Иван', 'id': 1}, {'first_name': 'Петр', 'id': 2}],
+            [{'first_name': '[Cleaned]', 'id': 1}, {'first_name': '[Cleaned]', 'id': 2}],
+        ),
+    ],
+)
+def test_clear_sensitive_data_pydantic_serializer(
+    data, expected_data, pydantic_model_serializer_with_sensitive_data
+):
+    result = clear_sensitive_data(data, pydantic_model_serializer_with_sensitive_data)
+
+    assert result == expected_data


### PR DESCRIPTION
Added support for sensitive data in `PydanticSerializer` class
Example:
```
class ConcreteDto(BaseModel):
    field1: str
    field2: int

class ConcretePydanticSerializer(PydanticSerializer[ConcreteDto]):
    class Meta:
        pydantic_model = ConcreteDto

    class SensitiveData:
        include = ['field1']
```